### PR TITLE
사용자 매너 평가 기능 구현

### DIFF
--- a/src/main/java/com/flab/buywithme/controller/MemberEvaluationController.java
+++ b/src/main/java/com/flab/buywithme/controller/MemberEvaluationController.java
@@ -1,0 +1,43 @@
+package com.flab.buywithme.controller;
+
+import com.flab.buywithme.domain.MemberEvaluation;
+import com.flab.buywithme.dto.MemberEvaluationDTO;
+import com.flab.buywithme.service.MemberEvaluationService;
+import com.flab.buywithme.utils.SessionConst;
+import java.util.List;
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.SessionAttribute;
+
+@RestController
+@RequestMapping("/evaluations")
+@RequiredArgsConstructor
+public class MemberEvaluationController {
+
+    private final MemberEvaluationService memberEvaluationService;
+
+    @PostMapping("/{postId}/{memberId}")
+    public void createEvaluation(@Valid @RequestBody MemberEvaluationDTO evaluationDTO,
+            @PathVariable Long postId,
+            @SessionAttribute(name = SessionConst.LOGIN_MEMBER) Long memberId,
+            @PathVariable("memberId") Long colleagueId) {
+        memberEvaluationService.saveEvaluation(evaluationDTO, postId, memberId, colleagueId);
+    }
+
+    @GetMapping
+    public List<MemberEvaluation> getAllEvaluations(
+            @SessionAttribute(name = SessionConst.LOGIN_MEMBER) Long memberId) {
+        return memberEvaluationService.getAllEvaluations(memberId);
+    }
+
+    @GetMapping("/{evaluationId}")
+    public MemberEvaluation getEvaluation(@PathVariable Long evaluationId) {
+        return memberEvaluationService.getEvaluation(evaluationId);
+    }
+}

--- a/src/main/java/com/flab/buywithme/controller/MemberEvaluationController.java
+++ b/src/main/java/com/flab/buywithme/controller/MemberEvaluationController.java
@@ -11,18 +11,16 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.SessionAttribute;
 
 @RestController
-@RequestMapping("/evaluations")
 @RequiredArgsConstructor
 public class MemberEvaluationController {
 
     private final MemberEvaluationService memberEvaluationService;
 
-    @PostMapping("/{postId}/{memberId}")
+    @PostMapping("/posts/{postId}/members/{memberId}/evaluations")
     public void createEvaluation(@Valid @RequestBody MemberEvaluationDTO evaluationDTO,
             @PathVariable Long postId,
             @SessionAttribute(name = SessionConst.LOGIN_MEMBER) Long memberId,
@@ -30,13 +28,13 @@ public class MemberEvaluationController {
         memberEvaluationService.saveEvaluation(evaluationDTO, postId, memberId, colleagueId);
     }
 
-    @GetMapping
+    @GetMapping("/evaluations")
     public List<MemberEvaluation> getAllEvaluations(
             @SessionAttribute(name = SessionConst.LOGIN_MEMBER) Long memberId) {
         return memberEvaluationService.getAllEvaluations(memberId);
     }
 
-    @GetMapping("/{evaluationId}")
+    @GetMapping("/evaluations/{evaluationId}")
     public MemberEvaluation getEvaluation(@PathVariable Long evaluationId) {
         return memberEvaluationService.getEvaluation(evaluationId);
     }

--- a/src/main/java/com/flab/buywithme/controller/PostController.java
+++ b/src/main/java/com/flab/buywithme/controller/PostController.java
@@ -1,6 +1,7 @@
 package com.flab.buywithme.controller;
 
 import com.flab.buywithme.domain.Post;
+import com.flab.buywithme.domain.enums.PostStatus;
 import com.flab.buywithme.dto.PostDTO;
 import com.flab.buywithme.service.PostService;
 import com.flab.buywithme.service.common.CommonPostService;
@@ -13,6 +14,7 @@ import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -59,6 +61,13 @@ public class PostController {
     @GetMapping("/{postId}")
     public Post getPost(@PathVariable Long postId) {
         return commonPostService.getPost(postId);
+    }
+
+    @PatchMapping("/{postId}")
+    public void updatePostStatus(@PathVariable Long postId,
+            @SessionAttribute(name = SessionConst.LOGIN_MEMBER) Long memberId,
+            @RequestParam("postStatus") PostStatus postStatus) {
+        postService.updatePostStatus(postId, memberId, postStatus);
     }
 
     @PutMapping("/{postId}")

--- a/src/main/java/com/flab/buywithme/domain/Member.java
+++ b/src/main/java/com/flab/buywithme/domain/Member.java
@@ -3,7 +3,6 @@ package com.flab.buywithme.domain;
 import static javax.persistence.FetchType.LAZY;
 
 import com.google.common.annotations.VisibleForTesting;
-import java.util.List;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -12,7 +11,6 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -39,15 +37,6 @@ public class Member {
     private String loginId;
 
     private String password;
-
-    @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE)
-    private List<Enroll> enrolls;
-
-    @OneToMany(mappedBy = "colleague", cascade = CascadeType.REMOVE)
-    private List<MemberEvaluation> receivedEvaluations;
-
-    @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE)
-    private List<MemberEvaluation> sentEvaluations;
 
     public Member(Address address, String name, String phoneNo, String loginId,
             String password) {

--- a/src/main/java/com/flab/buywithme/domain/Member.java
+++ b/src/main/java/com/flab/buywithme/domain/Member.java
@@ -43,6 +43,12 @@ public class Member {
     @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE)
     private List<Enroll> enrolls;
 
+    @OneToMany(mappedBy = "colleague", cascade = CascadeType.REMOVE)
+    private List<MemberEvaluation> receivedEvaluations;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE)
+    private List<MemberEvaluation> sentEvaluations;
+
     public Member(Address address, String name, String phoneNo, String loginId,
             String password) {
         this.address = address;

--- a/src/main/java/com/flab/buywithme/domain/MemberEvaluation.java
+++ b/src/main/java/com/flab/buywithme/domain/MemberEvaluation.java
@@ -1,0 +1,50 @@
+package com.flab.buywithme.domain;
+
+import java.time.LocalDateTime;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@EqualsAndHashCode(of = "id")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MemberEvaluation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "evaluation_id")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne
+    @JoinColumn(name = "colleague_id")
+    private Member colleague;
+
+    private String content;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/flab/buywithme/domain/Notification.java
+++ b/src/main/java/com/flab/buywithme/domain/Notification.java
@@ -43,6 +43,8 @@ public class Notification {
 
     private boolean checked;
 
+    private String formUrl;
+
     @CreatedDate
     private LocalDateTime createdAt;
 

--- a/src/main/java/com/flab/buywithme/domain/Post.java
+++ b/src/main/java/com/flab/buywithme/domain/Post.java
@@ -68,6 +68,9 @@ public class Post {
     @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE)
     private List<Enroll> enrolls;
 
+    @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE)
+    private List<MemberEvaluation> evaluations;
+
     public void update(String title, String content, int targetNo, LocalDateTime expiration) {
         this.title = title;
         this.content = content;
@@ -82,8 +85,12 @@ public class Post {
     public void increaseCurrentNo() {
         this.currentNo += 1;
         if (this.currentNo == this.targetNo) {
-            this.status = PostStatus.COMPLETE;
+            this.status = PostStatus.GATHER_COMPLETE;
         }
+    }
+
+    public void updateStatus(PostStatus postStatus) {
+        this.status = postStatus;
     }
 
     @VisibleForTesting

--- a/src/main/java/com/flab/buywithme/domain/Post.java
+++ b/src/main/java/com/flab/buywithme/domain/Post.java
@@ -3,6 +3,7 @@ package com.flab.buywithme.domain;
 import com.flab.buywithme.domain.enums.PostStatus;
 import com.google.common.annotations.VisibleForTesting;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
@@ -62,14 +63,17 @@ public class Post {
     @CreatedDate
     private LocalDateTime createdAt;
 
+    @Builder.Default
     @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE)
-    private List<PostComment> comments;
+    private List<PostComment> comments = new ArrayList<>();
 
+    @Builder.Default
     @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE)
-    private List<Enroll> enrolls;
+    private List<Enroll> enrolls = new ArrayList<>();
 
+    @Builder.Default
     @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE)
-    private List<MemberEvaluation> evaluations;
+    private List<MemberEvaluation> evaluations = new ArrayList<>();
 
     public void update(String title, String content, int targetNo, LocalDateTime expiration) {
         this.title = title;
@@ -91,6 +95,18 @@ public class Post {
 
     public void updateStatus(PostStatus postStatus) {
         this.status = postStatus;
+    }
+
+    public void addEnroll(Enroll enroll) {
+        enrolls.add(enroll);
+    }
+
+    public void addComment(PostComment comment) {
+        comments.add(comment);
+    }
+
+    public void addEvaluation(MemberEvaluation evaluation) {
+        evaluations.add(evaluation);
     }
 
     @VisibleForTesting

--- a/src/main/java/com/flab/buywithme/domain/PostComment.java
+++ b/src/main/java/com/flab/buywithme/domain/PostComment.java
@@ -66,4 +66,8 @@ public class PostComment {
     public boolean checkIsOwner(Long memberId) {
         return this.member.getId().equals(memberId);
     }
+
+    public void addChildren(PostComment comment) {
+        children.add(comment);
+    }
 }

--- a/src/main/java/com/flab/buywithme/domain/enums/PostStatus.java
+++ b/src/main/java/com/flab/buywithme/domain/enums/PostStatus.java
@@ -1,5 +1,5 @@
 package com.flab.buywithme.domain.enums;
 
 public enum PostStatus {
-    RUNNING, COMPLETE
+    RUNNING, GATHER_COMPLETE, BUYING_COMPLETE
 }

--- a/src/main/java/com/flab/buywithme/dto/MemberEvaluationDTO.java
+++ b/src/main/java/com/flab/buywithme/dto/MemberEvaluationDTO.java
@@ -1,0 +1,19 @@
+package com.flab.buywithme.dto;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class MemberEvaluationDTO {
+
+    @NotBlank
+    @Size(max = 100)
+    private String content;
+}

--- a/src/main/java/com/flab/buywithme/error/ErrorCode.java
+++ b/src/main/java/com/flab/buywithme/error/ErrorCode.java
@@ -25,11 +25,13 @@ public enum ErrorCode {
     COMMENT_NOT_FOUND(NOT_FOUND, "해당 댓글이 존재하지 않습니다"),
     ENROLL_NOT_FOUND(NOT_FOUND, "등록 정보가 존재하지 않습니다"),
     NOTIFICATION_NOT_FOUND(NOT_FOUND, "해당 알림이 존재하지 않습니다"),
+    EVALUATION_NOT_FOUND(NOT_FOUND, "해당 매너 평가가 존재하지 않습니다"),
 
     /* 409 CONFLICT : 서버의 상태와 충돌하는 경우 */
     MEMBER_ALREADY_EXIST(CONFLICT, "이미 존재하는 회원입니다"),
     GATHERING_FINISHED(CONFLICT, "인원 모집이 마감되었습니다"),
-    ENROLL_ALREADY_DONE(CONFLICT, "이미 구매에 참여했습니다");
+    ENROLL_ALREADY_DONE(CONFLICT, "이미 구매에 참여했습니다"),
+    NOT_ENROLLED_MEMBER(CONFLICT, "해당 구매에 참여하지 않은 멤버입니다");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/flab/buywithme/event/DomainEventHandlerImpl/CreateNotificationWhenCreateComment.java
+++ b/src/main/java/com/flab/buywithme/event/DomainEventHandlerImpl/CreateNotificationWhenCreateComment.java
@@ -8,6 +8,7 @@ import com.flab.buywithme.event.DomainEventType;
 import com.flab.buywithme.repository.NotificationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
@@ -21,6 +22,7 @@ public class CreateNotificationWhenCreateComment implements DomainEventHandler<P
     }
 
     @Override
+    @Transactional
     public void handle(DomainEvent<Post> event) {
         Post post = event.getSource();
 

--- a/src/main/java/com/flab/buywithme/event/DomainEventHandlerImpl/CreateNotificationWhenCreateSubComment.java
+++ b/src/main/java/com/flab/buywithme/event/DomainEventHandlerImpl/CreateNotificationWhenCreateSubComment.java
@@ -8,6 +8,7 @@ import com.flab.buywithme.event.DomainEventType;
 import com.flab.buywithme.repository.NotificationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
@@ -21,6 +22,7 @@ public class CreateNotificationWhenCreateSubComment implements DomainEventHandle
     }
 
     @Override
+    @Transactional
     public void handle(DomainEvent<PostComment> event) {
         PostComment comment = event.getSource();
 

--- a/src/main/java/com/flab/buywithme/event/DomainEventHandlerImpl/CreateNotificationWhenDeletePost.java
+++ b/src/main/java/com/flab/buywithme/event/DomainEventHandlerImpl/CreateNotificationWhenDeletePost.java
@@ -10,6 +10,7 @@ import com.flab.buywithme.repository.NotificationRepository;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
@@ -23,6 +24,7 @@ public class CreateNotificationWhenDeletePost implements DomainEventHandler<Post
     }
 
     @Override
+    @Transactional
     public void handle(DomainEvent<Post> event) {
         Post post = event.getSource();
 

--- a/src/main/java/com/flab/buywithme/event/DomainEventHandlerImpl/CreateNotificationWhenPostStatusUpdatedToBuyingComplete.java
+++ b/src/main/java/com/flab/buywithme/event/DomainEventHandlerImpl/CreateNotificationWhenPostStatusUpdatedToBuyingComplete.java
@@ -14,6 +14,7 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
@@ -29,6 +30,7 @@ public class CreateNotificationWhenPostStatusUpdatedToBuyingComplete implements
     }
 
     @Override
+    @Transactional
     public void handle(DomainEvent<Post> event) {
         Post post = event.getSource();
 

--- a/src/main/java/com/flab/buywithme/event/DomainEventHandlerImpl/CreateNotificationWhenPostStatusUpdatedToBuyingComplete.java
+++ b/src/main/java/com/flab/buywithme/event/DomainEventHandlerImpl/CreateNotificationWhenPostStatusUpdatedToBuyingComplete.java
@@ -17,14 +17,15 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class CreateNotificationWhenPostStatusUpdatedToComplete implements DomainEventHandler<Post> {
+public class CreateNotificationWhenPostStatusUpdatedToBuyingComplete implements
+        DomainEventHandler<Post> {
 
     private final NotificationRepository notificationRepository;
 
     @Override
     public boolean canHandle(DomainEvent<Post> event) {
         return event.getDomainEventType() == DomainEventType.UPDATE_POST
-                && event.getSource().getStatus() == PostStatus.COMPLETE;
+                && event.getSource().getStatus() == PostStatus.BUYING_COMPLETE;
     }
 
     @Override
@@ -38,13 +39,20 @@ public class CreateNotificationWhenPostStatusUpdatedToComplete implements Domain
         members.add(post.getMember());
 
         for (Member member : members) {
-            notificationRepository.save(
-                    Notification.builder()
-                            .member(member)
-                            .checked(false)
-                            .domainEventType(event.getDomainEventType())
-                            .build()
-            );
+            for (Member colleague : members) {
+                if (member.equals(colleague)) {
+                    continue;
+                }
+                notificationRepository.save(
+                        Notification.builder()
+                                .member(member)
+                                .checked(false)
+                                .formUrl("/colleagueEvaluateForm/" + post.getId() + "/"
+                                        + colleague.getId())
+                                .domainEventType(event.getDomainEventType())
+                                .build()
+                );
+            }
         }
     }
 }

--- a/src/main/java/com/flab/buywithme/event/DomainEventHandlerImpl/CreateNotificationWhenPostStatusUpdatedToGatherComplete.java
+++ b/src/main/java/com/flab/buywithme/event/DomainEventHandlerImpl/CreateNotificationWhenPostStatusUpdatedToGatherComplete.java
@@ -1,0 +1,51 @@
+package com.flab.buywithme.event.DomainEventHandlerImpl;
+
+import com.flab.buywithme.domain.Enroll;
+import com.flab.buywithme.domain.Member;
+import com.flab.buywithme.domain.Notification;
+import com.flab.buywithme.domain.Post;
+import com.flab.buywithme.domain.enums.PostStatus;
+import com.flab.buywithme.event.DomainEvent;
+import com.flab.buywithme.event.DomainEventHandler;
+import com.flab.buywithme.event.DomainEventType;
+import com.flab.buywithme.repository.NotificationRepository;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.collections4.CollectionUtils;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CreateNotificationWhenPostStatusUpdatedToGatherComplete implements
+        DomainEventHandler<Post> {
+
+    private final NotificationRepository notificationRepository;
+
+    @Override
+    public boolean canHandle(DomainEvent<Post> event) {
+        return event.getDomainEventType() == DomainEventType.UPDATE_POST
+                && event.getSource().getStatus() == PostStatus.GATHER_COMPLETE;
+    }
+
+    @Override
+    public void handle(DomainEvent<Post> event) {
+        Post post = event.getSource();
+
+        List<Member> members = CollectionUtils.emptyIfNull(post.getEnrolls()).stream()
+                .map(Enroll::getMember)
+                .collect(Collectors.toList());
+
+        members.add(post.getMember());
+
+        for (Member member : members) {
+            notificationRepository.save(
+                    Notification.builder()
+                            .member(member)
+                            .checked(false)
+                            .domainEventType(event.getDomainEventType())
+                            .build()
+            );
+        }
+    }
+}

--- a/src/main/java/com/flab/buywithme/event/DomainEventHandlerImpl/CreateNotificationWhenPostStatusUpdatedToGatherComplete.java
+++ b/src/main/java/com/flab/buywithme/event/DomainEventHandlerImpl/CreateNotificationWhenPostStatusUpdatedToGatherComplete.java
@@ -14,6 +14,7 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
@@ -29,6 +30,7 @@ public class CreateNotificationWhenPostStatusUpdatedToGatherComplete implements
     }
 
     @Override
+    @Transactional
     public void handle(DomainEvent<Post> event) {
         Post post = event.getSource();
 

--- a/src/main/java/com/flab/buywithme/event/DomainEventListener.java
+++ b/src/main/java/com/flab/buywithme/event/DomainEventListener.java
@@ -2,9 +2,9 @@ package com.flab.buywithme.event;
 
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 @Async
 @Component
@@ -13,7 +13,7 @@ public class DomainEventListener {
     @Autowired
     private List<DomainEventHandler> handlers;
 
-    @EventListener
+    @TransactionalEventListener
     public void handleDomainEvent(DomainEvent event) {
         for (DomainEventHandler handler : handlers) {
             if (handler.canHandle(event)) {

--- a/src/main/java/com/flab/buywithme/repository/MemberEvaluationRepository.java
+++ b/src/main/java/com/flab/buywithme/repository/MemberEvaluationRepository.java
@@ -1,0 +1,14 @@
+package com.flab.buywithme.repository;
+
+import com.flab.buywithme.domain.MemberEvaluation;
+import com.google.common.annotations.VisibleForTesting;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberEvaluationRepository extends JpaRepository<MemberEvaluation, Long> {
+
+    List<MemberEvaluation> findAllByColleagueId(Long memberId);
+
+    @VisibleForTesting
+    List<MemberEvaluation> findAllByPost_Id(Long postId);
+}

--- a/src/main/java/com/flab/buywithme/service/EnrollService.java
+++ b/src/main/java/com/flab/buywithme/service/EnrollService.java
@@ -37,6 +37,7 @@ public class EnrollService {
 
         commonPostService.increaseJoinCount(post);
         enrollRepository.save(enroll);
+        post.addEnroll(enroll);
     }
 
     public void cancelJoining(Long postId, Long memberId) {

--- a/src/main/java/com/flab/buywithme/service/MemberEvaluationService.java
+++ b/src/main/java/com/flab/buywithme/service/MemberEvaluationService.java
@@ -1,0 +1,65 @@
+package com.flab.buywithme.service;
+
+import com.flab.buywithme.domain.Member;
+import com.flab.buywithme.domain.MemberEvaluation;
+import com.flab.buywithme.domain.Post;
+import com.flab.buywithme.dto.MemberEvaluationDTO;
+import com.flab.buywithme.error.CustomException;
+import com.flab.buywithme.error.ErrorCode;
+import com.flab.buywithme.repository.MemberEvaluationRepository;
+import com.flab.buywithme.service.common.CommonMemberService;
+import com.flab.buywithme.service.common.CommonPostService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.collections4.CollectionUtils;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MemberEvaluationService {
+
+    private final CommonMemberService commonMemberService;
+    private final CommonPostService commonPostService;
+    private final MemberEvaluationRepository memberEvaluationRepository;
+
+    public Long saveEvaluation(MemberEvaluationDTO evaluationDTO, Long postId, Long memberId,
+            Long colleagueId) {
+        Member member = commonMemberService.getMember(memberId);
+
+        Member colleague = commonMemberService.getMember(colleagueId);
+
+        Post post = commonPostService.getPost(postId);
+
+        CollectionUtils.emptyIfNull(post.getEnrolls()).stream()
+                .filter(e -> e.getMember().equals(member)).findAny()
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_ENROLLED_MEMBER));
+
+        CollectionUtils.emptyIfNull(post.getEnrolls()).stream()
+                .filter(e -> e.getMember().equals(colleague)).findAny()
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_ENROLLED_MEMBER));
+
+        MemberEvaluation newEvaluation = MemberEvaluation.builder()
+                .post(post)
+                .member(member)
+                .colleague(colleague)
+                .content(evaluationDTO.getContent())
+                .build();
+
+        memberEvaluationRepository.save(newEvaluation);
+
+        return newEvaluation.getId();
+    }
+
+    @Transactional(readOnly = true)
+    public List<MemberEvaluation> getAllEvaluations(Long memberId) {
+        return memberEvaluationRepository.findAllByColleagueId(memberId);
+    }
+
+    @Transactional(readOnly = true)
+    public MemberEvaluation getEvaluation(Long evaluationId) {
+        return memberEvaluationRepository.findById(evaluationId)
+                .orElseThrow(() -> new CustomException(ErrorCode.EVALUATION_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/flab/buywithme/service/MemberEvaluationService.java
+++ b/src/main/java/com/flab/buywithme/service/MemberEvaluationService.java
@@ -49,6 +49,8 @@ public class MemberEvaluationService {
 
         memberEvaluationRepository.save(newEvaluation);
 
+        post.addEvaluation(newEvaluation);
+
         return newEvaluation.getId();
     }
 

--- a/src/main/java/com/flab/buywithme/service/PostCommentService.java
+++ b/src/main/java/com/flab/buywithme/service/PostCommentService.java
@@ -40,6 +40,8 @@ public class PostCommentService {
 
         commentRepository.save(newComment);
 
+        post.addComment(newComment);
+
         applicationEventPublisher.publishEvent(
                 new DomainEvent<>(DomainEventType.CREATE_COMMENT, post));
 
@@ -66,6 +68,8 @@ public class PostCommentService {
                 .build();
 
         commentRepository.save(newComment);
+
+        parent.addChildren(newComment);
 
         applicationEventPublisher.publishEvent(
                 new DomainEvent<>(DomainEventType.CREATE_SUB_COMMENT, parent));

--- a/src/main/java/com/flab/buywithme/service/PostService.java
+++ b/src/main/java/com/flab/buywithme/service/PostService.java
@@ -2,6 +2,7 @@ package com.flab.buywithme.service;
 
 import com.flab.buywithme.domain.Member;
 import com.flab.buywithme.domain.Post;
+import com.flab.buywithme.domain.enums.PostStatus;
 import com.flab.buywithme.dto.PostDTO;
 import com.flab.buywithme.error.CustomException;
 import com.flab.buywithme.error.ErrorCode;
@@ -55,6 +56,15 @@ public class PostService {
     @Transactional(readOnly = true)
     public Page<Post> getPostsByAddress(Long addressId, Pageable pageable) {
         return postRepository.findByAddress_Id(addressId, pageable);
+    }
+
+    public void updatePostStatus(Long postId, Long memberId, PostStatus postStatus) {
+        Post post = commonPostService.getPost(postId);
+        checkWhetherAuthor(post, memberId);
+        post.updateStatus(postStatus);
+
+        eventPublisher.publishEvent(
+                new DomainEvent<>(DomainEventType.UPDATE_POST, post));
     }
 
     public void updatePost(Long postId, Long memberId, PostDTO postDTO) {

--- a/src/main/java/com/flab/buywithme/service/common/CommonPostService.java
+++ b/src/main/java/com/flab/buywithme/service/common/CommonPostService.java
@@ -32,12 +32,12 @@ public class CommonPostService {
 
     @Transactional
     public void increaseJoinCount(Post post) {
-        if (post.getStatus() == PostStatus.COMPLETE) {
+        if (post.getStatus() == PostStatus.GATHER_COMPLETE) {
             throw new CustomException(ErrorCode.GATHERING_FINISHED);
         } else {
             post.increaseCurrentNo();
 
-            if (post.getStatus() == PostStatus.COMPLETE) {
+            if (post.getStatus() == PostStatus.GATHER_COMPLETE) {
                 applicationEventPublisher.publishEvent(
                         new DomainEvent<>(DomainEventType.UPDATE_POST, post));
             }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -11,7 +11,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: validate
+      ddl-auto: none
 
 logging:
   level:

--- a/src/main/resources/sql/schema.sql
+++ b/src/main/resources/sql/schema.sql
@@ -81,11 +81,28 @@ CREATE TABLE IF NOT EXISTS `notification`
     `notification_id`   bigint NOT NULL AUTO_INCREMENT,
     `checked`           bit(1) NOT NULL,
     `notification_type` varchar(255),
+    `member_id`         bigint,
+    `form_url`          varchar(255),
     `created_at`        datetime(6),
     `updated_at`        datetime(6),
-    `member_id`         bigint,
     PRIMARY KEY (`notification_id`),
     FOREIGN KEY (`member_id`) REFERENCES `member` (`member_id`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_0900_ai_ci;
+
+CREATE TABLE IF NOT EXISTS `member_evaluation`
+(
+    `evaluation_id` bigint NOT NULL AUTO_INCREMENT,
+    `post_id`       bigint,
+    `member_id`     bigint,
+    `colleague_id`  bigint,
+    `created_at`    datetime(6),
+    `content`       varchar(255),
+    PRIMARY KEY (`evaluation_id`),
+    FOREIGN KEY (`member_id`) REFERENCES `member` (`member_id`),
+    FOREIGN KEY (`post_id`) REFERENCES `post` (`post_id`),
+    FOREIGN KEY (`colleague_id`) REFERENCES `member` (`member_id`)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
   COLLATE = utf8mb4_0900_ai_ci;

--- a/src/test/java/com/flab/buywithme/controller/MemberEvaluationControllerTest.java
+++ b/src/test/java/com/flab/buywithme/controller/MemberEvaluationControllerTest.java
@@ -57,7 +57,7 @@ class MemberEvaluationControllerTest {
     public void createEvaluation() throws Exception {
         MemberEvaluationDTO memberEvaluationDTO = fakeMemberEvaluationDTO();
 
-        mockMvc.perform(post("/evaluations/" + postId + "/" + colleagueId)
+        mockMvc.perform(post("/posts/" + postId + "/members/" + colleagueId + "/evaluations")
                         .content(objectMapper.writeValueAsString(memberEvaluationDTO))
                         .contentType(MediaType.APPLICATION_JSON)
                         .sessionAttr("memberId", memberId)

--- a/src/test/java/com/flab/buywithme/controller/MemberEvaluationControllerTest.java
+++ b/src/test/java/com/flab/buywithme/controller/MemberEvaluationControllerTest.java
@@ -1,0 +1,94 @@
+package com.flab.buywithme.controller;
+
+import static com.flab.buywithme.TestFixture.fakeMemberEvaluationDTO;
+import static org.mockito.BDDMockito.then;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.log;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.flab.buywithme.config.TestConfig;
+import com.flab.buywithme.dto.MemberEvaluationDTO;
+import com.flab.buywithme.service.MemberEvaluationService;
+import com.flab.buywithme.utils.SessionConst;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = MemberEvaluationController.class)
+@Import(TestConfig.class)
+class MemberEvaluationControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private MemberEvaluationService memberEvaluationService;
+
+    private MockHttpSession mockSession;
+    private Long postId;
+    private Long memberId;
+    private Long colleagueId;
+    private Long evaluationId;
+
+    @BeforeEach
+    public void setUp() {
+        mockSession = new MockHttpSession();
+        mockSession.setAttribute(SessionConst.LOGIN_MEMBER, 1L);
+        postId = 1L;
+        memberId = 1L;
+        colleagueId = 2L;
+        evaluationId = 1L;
+    }
+
+    @Test
+    @DisplayName("매너 평가 작성 요청 성공")
+    public void createEvaluation() throws Exception {
+        MemberEvaluationDTO memberEvaluationDTO = fakeMemberEvaluationDTO();
+
+        mockMvc.perform(post("/evaluations/" + postId + "/" + colleagueId)
+                        .content(objectMapper.writeValueAsString(memberEvaluationDTO))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .sessionAttr("memberId", memberId)
+                        .session(mockSession))
+                .andExpect(status().is2xxSuccessful())
+                .andDo(log());
+
+        then(memberEvaluationService).should()
+                .saveEvaluation(memberEvaluationDTO, postId, memberId, colleagueId);
+    }
+
+    @Test
+    @DisplayName("멤버별 받은 매너 평가 가져오기 요청 성공")
+    public void getAllEvaluations() throws Exception {
+        mockMvc.perform(get("/evaluations")
+                        .sessionAttr("memberId", memberId)
+                        .session(mockSession))
+                .andExpect(status().is2xxSuccessful())
+                .andDo(log());
+
+        then(memberEvaluationService).should().getAllEvaluations(memberId);
+    }
+
+    @Test
+    @DisplayName("특정 매너평가 가져오기 요청 성공")
+    public void getEvaluation() throws Exception {
+        mockMvc.perform(get("/evaluations/" + evaluationId)
+                        .session(mockSession))
+                .andExpect(status().is2xxSuccessful())
+                .andDo(log());
+
+        then(memberEvaluationService).should().getEvaluation(evaluationId);
+    }
+}

--- a/src/test/java/com/flab/buywithme/controller/PostControllerTest.java
+++ b/src/test/java/com/flab/buywithme/controller/PostControllerTest.java
@@ -5,6 +5,7 @@ import static com.flab.buywithme.TestFixture.fakePostDTO;
 import static org.mockito.BDDMockito.then;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.log;
@@ -12,9 +13,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.flab.buywithme.config.TestConfig;
+import com.flab.buywithme.domain.enums.PostStatus;
 import com.flab.buywithme.dto.PostDTO;
 import com.flab.buywithme.service.PostService;
-import com.flab.buywithme.service.common.CommonMemberService;
 import com.flab.buywithme.service.common.CommonPostService;
 import com.flab.buywithme.utils.SessionConst;
 import java.time.LocalDateTime;
@@ -43,9 +44,6 @@ class PostControllerTest {
 
     @MockBean
     private PostService postService;
-
-    @MockBean
-    private CommonMemberService commonMemberService;
 
     @MockBean
     private CommonPostService commonPostService;
@@ -137,6 +135,19 @@ class PostControllerTest {
                 .andDo(log());
 
         then(commonPostService).should().getPost(postId);
+    }
+
+    @Test
+    @DisplayName("게시글 상태 업데이트 요청 성공")
+    public void updatePostStatus() throws Exception {
+        mockMvc.perform(patch("/posts/" + postId)
+                        .param("postStatus", "BUYING_COMPLETE")
+                        .sessionAttr("memberId", memberId)
+                        .session(mockSession))
+                .andExpect(status().is2xxSuccessful())
+                .andDo(log());
+
+        then(postService).should().updatePostStatus(postId, memberId, PostStatus.BUYING_COMPLETE);
     }
 
     @Test

--- a/src/test/java/com/flab/buywithme/repository/MemberEvaluationRepositoryTest.java
+++ b/src/test/java/com/flab/buywithme/repository/MemberEvaluationRepositoryTest.java
@@ -1,0 +1,56 @@
+package com.flab.buywithme.repository;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.flab.buywithme.config.JasyptConfig;
+import com.flab.buywithme.config.JpaAuditingConfig;
+import java.sql.Connection;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.jdbc.datasource.init.ScriptUtils;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+@TestInstance(Lifecycle.PER_CLASS)
+@Import({JasyptConfig.class, JpaAuditingConfig.class})
+class MemberEvaluationRepositoryTest {
+
+    @Autowired
+    private MemberEvaluationRepository evaluationRepository;
+
+    @Autowired
+    private DataSource dataSource;
+
+    private final Long memberId = 1L;
+
+    @BeforeAll
+    public void beforeAll() throws Exception {
+        try (Connection conn = dataSource.getConnection()) {
+            ScriptUtils.executeSqlScript(conn, new ClassPathResource("sql/data.sql"));
+        }
+    }
+
+    @AfterAll
+    public void afterAll() throws Exception {
+        try (Connection conn = dataSource.getConnection()) {
+            ScriptUtils.executeSqlScript(conn, new ClassPathResource("sql/truncate.sql"));
+        }
+    }
+
+    @Test
+    @DisplayName("나에 대한 타인의 매너 평가 결과 가져오기 성공")
+    void findAllByColleagueIdSucess() {
+        assertTrue(evaluationRepository.findAllByColleagueId(memberId).size() > 0);
+    }
+}

--- a/src/test/java/com/flab/buywithme/repository/PostRepositoryTest.java
+++ b/src/test/java/com/flab/buywithme/repository/PostRepositoryTest.java
@@ -46,6 +46,9 @@ class PostRepositoryTest {
     private EnrollRepository enrollRepository;
 
     @Autowired
+    private MemberEvaluationRepository memberEvaluationRepository;
+
+    @Autowired
     private DataSource dataSource;
 
     private final Long postId = 1L;
@@ -105,15 +108,17 @@ class PostRepositoryTest {
     }
 
     @Test
-    @DisplayName("게시글 삭제 시 해당 게시글의 댓글과 구매 참여 내역도 같이 삭제 성공")
+    @DisplayName("게시글 삭제 시 해당 게시글의 댓글과 구매 참여 내역, 멤버 간 평가도 같이 삭제 성공")
     void deletePostWithComment() {
         assertFalse(postCommentRepository.findAllByPost_Id(postId).isEmpty());
         assertFalse(enrollRepository.findAllByPost_Id(postId).isEmpty());
+        assertFalse(memberEvaluationRepository.findAllByPost_Id(postId).isEmpty());
 
         postRepository.deleteById(postId);
 
         assertTrue(postRepository.findById(postId).isEmpty());
         assertTrue(postCommentRepository.findAllByPost_Id(postId).isEmpty());
         assertTrue(enrollRepository.findAllByPost_Id(postId).isEmpty());
+        assertTrue(memberEvaluationRepository.findAllByPost_Id(postId).isEmpty());
     }
 }

--- a/src/test/java/com/flab/buywithme/service/MemberEvaluationServiceTest.java
+++ b/src/test/java/com/flab/buywithme/service/MemberEvaluationServiceTest.java
@@ -1,0 +1,160 @@
+package com.flab.buywithme.service;
+
+import static com.flab.buywithme.TestFixture.fakeEnroll;
+import static com.flab.buywithme.TestFixture.fakeMember;
+import static com.flab.buywithme.TestFixture.fakeMemberEvaluation;
+import static com.flab.buywithme.TestFixture.fakeMemberEvaluationDTO;
+import static com.flab.buywithme.TestFixture.fakePost;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.flab.buywithme.domain.Enroll;
+import com.flab.buywithme.domain.Member;
+import com.flab.buywithme.domain.MemberEvaluation;
+import com.flab.buywithme.domain.Post;
+import com.flab.buywithme.dto.MemberEvaluationDTO;
+import com.flab.buywithme.error.CustomException;
+import com.flab.buywithme.error.ErrorCode;
+import com.flab.buywithme.repository.MemberEvaluationRepository;
+import com.flab.buywithme.service.common.CommonMemberService;
+import com.flab.buywithme.service.common.CommonPostService;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MemberEvaluationServiceTest {
+
+    @InjectMocks
+    private MemberEvaluationService memberEvaluationService;
+
+    @Mock
+    private MemberEvaluationRepository memberEvaluationRepository;
+
+    @Mock
+    private CommonMemberService commonMemberService;
+
+    @Mock
+    private CommonPostService commonPostService;
+
+    private Long postId;
+    private Long memberId;
+    private Long colleagueId;
+    private Long evaluationId;
+    private MemberEvaluation memberEvaluation;
+
+    @BeforeEach
+    public void setup() {
+        postId = 1L;
+        memberId = 1L;
+        colleagueId = 2L;
+        evaluationId = 1L;
+        memberEvaluation = fakeMemberEvaluation(evaluationId);
+    }
+
+    @Test
+    @DisplayName("매너 평가 성공")
+    public void saveEvaluationSuccess() {
+        Member currentMember = fakeMember(memberId);
+        Member colleague = fakeMember(colleagueId);
+        Post currentPost = fakePost(postId);
+        List<Enroll> fakeEnrollList = Arrays.asList(fakeEnroll(1L), fakeEnroll(2L));
+        fakeEnrollList.get(1).getMember().setId(colleagueId);
+        currentPost.setEnrolls(fakeEnrollList);
+        MemberEvaluationDTO memberEvaluationDTO = fakeMemberEvaluationDTO();
+
+        given(commonMemberService.getMember(memberId))
+                .willReturn(currentMember);
+        given(commonMemberService.getMember(colleagueId))
+                .willReturn(colleague);
+        given(commonPostService.getPost(anyLong()))
+                .willReturn(currentPost);
+        given(memberEvaluationRepository.save(any(MemberEvaluation.class)))
+                .willReturn(memberEvaluation);
+
+        memberEvaluationService.saveEvaluation(memberEvaluationDTO, postId, memberId, colleagueId);
+
+        MemberEvaluation expected = MemberEvaluation.builder()
+                .post(currentPost)
+                .member(currentMember)
+                .colleague(colleague)
+                .content(memberEvaluationDTO.getContent())
+                .build();
+
+        then(commonMemberService).should().getMember(memberId);
+        then(commonMemberService).should().getMember(colleagueId);
+        then(commonPostService).should().getPost(postId);
+        then(memberEvaluationRepository).should().save(expected);
+    }
+
+    @Test
+    @DisplayName("구매에 참여하지 않은 멤버에 대한 평가는 저장 실패")
+    public void saveEvaluationFail() {
+        Member currentMember = fakeMember(memberId);
+        Member colleague = fakeMember(colleagueId);
+        Post currentPost = fakePost(postId);
+        currentPost.setEnrolls(Arrays.asList(fakeEnroll(1L)));
+        MemberEvaluationDTO memberEvaluationDTO = fakeMemberEvaluationDTO();
+
+        given(commonMemberService.getMember(memberId))
+                .willReturn(currentMember);
+        given(commonMemberService.getMember(colleagueId))
+                .willReturn(colleague);
+        given(commonPostService.getPost(anyLong()))
+                .willReturn(currentPost);
+
+        CustomException ex = assertThrows(CustomException.class,
+                () -> memberEvaluationService.saveEvaluation(memberEvaluationDTO, postId,
+                        memberId, colleagueId));
+
+        then(commonMemberService).should().getMember(memberId);
+        then(commonMemberService).should().getMember(colleagueId);
+        then(commonPostService).should().getPost(postId);
+        assertEquals(ex.getErrorCode(), ErrorCode.NOT_ENROLLED_MEMBER);
+        verify(memberEvaluationRepository, times(0)).save(any());
+    }
+
+    @Test
+    @DisplayName("멤버별 받은 매너 평가 내역 가져오기 성공")
+    public void getAllEvaluations() {
+        memberEvaluationService.getAllEvaluations(memberId);
+        then(memberEvaluationRepository).should().findAllByColleagueId(memberId);
+    }
+
+    @Test
+    @DisplayName("특정 매너 평가 가져오기 성공")
+    public void getEvaluationSuccess() {
+        given(memberEvaluationRepository.findById(anyLong()))
+                .willReturn(Optional.ofNullable(memberEvaluation));
+
+        memberEvaluationService.getEvaluation(evaluationId);
+
+        then(memberEvaluationRepository).should().findById(evaluationId);
+    }
+
+    @Test
+    @DisplayName("특정 매너 평가 가져오기 실패")
+    public void getEvaluationFail() {
+        given(memberEvaluationRepository.findById(anyLong()))
+                .willReturn(Optional.empty());
+
+        CustomException ex = assertThrows(CustomException.class,
+                () -> memberEvaluationService.getEvaluation(evaluationId));
+
+        then(memberEvaluationRepository).should().findById(evaluationId);
+        assertEquals(ex.getErrorCode(), ErrorCode.EVALUATION_NOT_FOUND);
+    }
+}

--- a/src/test/java/com/flab/buywithme/service/PostServiceTest.java
+++ b/src/test/java/com/flab/buywithme/service/PostServiceTest.java
@@ -13,6 +13,7 @@ import static org.mockito.BDDMockito.then;
 
 import com.flab.buywithme.domain.Member;
 import com.flab.buywithme.domain.Post;
+import com.flab.buywithme.domain.enums.PostStatus;
 import com.flab.buywithme.dto.PostDTO;
 import com.flab.buywithme.error.CustomException;
 import com.flab.buywithme.error.ErrorCode;
@@ -135,6 +136,20 @@ class PostServiceTest {
 
         then(commonPostService).should().getPost(postId);
         assertEquals(post.getTitle(), "수정 test 게시물");
+    }
+
+    @Test
+    @DisplayName("게시글 상태 업데이트 성공")
+    public void updatePostStatusSuccess() {
+        DomainEvent<Post> expected = new DomainEvent<>(DomainEventType.UPDATE_POST, post);
+        given(commonPostService.getPost(anyLong()))
+                .willReturn(post);
+
+        postService.updatePostStatus(postId, memberId, PostStatus.BUYING_COMPLETE);
+
+        then(commonPostService).should().getPost(postId);
+        assertEquals(PostStatus.BUYING_COMPLETE, post.getStatus());
+        then(applicationEventPublisher).should().publishEvent(expected);
     }
 
     @Test

--- a/src/test/resources/sql/data.sql
+++ b/src/test/resources/sql/data.sql
@@ -5,6 +5,10 @@ INSERT INTO member (login_id, name, password, phone_no, address_id)
 VALUES ("test", "kim", "1b4f0e9851971998e732078544c96b36c3d01cedf7caa332359d6f1d83567014",
         "010-1111-1111", 1);
 
+INSERT INTO member (login_id, name, password, phone_no, address_id)
+VALUES ("test2", "mun", "1b4f0e9851971998e732078544c96b36c3d01cedf7caa332359d6f1d83567014",
+        "010-1111-1111", 1);
+
 INSERT INTO post (title, content, created_at, expiration, status, current_no, target_no, address_id,
                   member_id)
 VALUES ("test 게시물", "test 목적으로 생성하였음", "2023-02-01 12:00:00", "2023-04-04 23:00:00", "RUNNING", 0,
@@ -28,11 +32,14 @@ VALUES (1, 1, "test comment");
 INSERT INTO post_comment (post_id, member_id, content, parent_id)
 VALUES (1, 1, "test sub comment", 1);
 
-INSERT INTO notification (notification_id, member_id, notification_type, checked)
-VALUES (1, 1, "CREATE_COMMENT", true);
+INSERT INTO notification (member_id, notification_type, checked)
+VALUES (1, "CREATE_COMMENT", true);
 
-INSERT INTO notification (notification_id, member_id, notification_type, checked)
-VALUES (2, 1, "UPDATE_POST", false);
+INSERT INTO notification (member_id, notification_type, checked)
+VALUES (1, "UPDATE_POST", false);
 
-INSERT INTO notification (notification_id, member_id, notification_type, checked)
-VALUES (3, 1, "DELETE_POST", false);
+INSERT INTO notification (member_id, notification_type, checked)
+VALUES (1, "DELETE_POST", false);
+
+INSERT INTO member_evaluation (post_id, member_id, colleague_id, content)
+VALUES (1, 2, 1, "test eval")

--- a/src/test/resources/sql/truncate.sql
+++ b/src/test/resources/sql/truncate.sql
@@ -5,4 +5,5 @@ TRUNCATE TABLE post;
 TRUNCATE TABLE enroll;
 TRUNCATE TABLE post_comment;
 TRUNCATE TABLE notification;
+TRUNCATE TABLE member_evaluation;
 set FOREIGN_KEY_CHECKS = 1;

--- a/src/testFixtures/java/com/flab/buywithme/TestFixture.java
+++ b/src/testFixtures/java/com/flab/buywithme/TestFixture.java
@@ -3,9 +3,11 @@ package com.flab.buywithme;
 import com.flab.buywithme.domain.Address;
 import com.flab.buywithme.domain.Enroll;
 import com.flab.buywithme.domain.Member;
+import com.flab.buywithme.domain.MemberEvaluation;
 import com.flab.buywithme.domain.Notification;
 import com.flab.buywithme.domain.Post;
 import com.flab.buywithme.domain.PostComment;
+import com.flab.buywithme.dto.MemberEvaluationDTO;
 import com.flab.buywithme.dto.PostCommentDTO;
 import com.flab.buywithme.dto.PostDTO;
 import com.flab.buywithme.event.DomainEventType;
@@ -109,5 +111,23 @@ public class TestFixture {
                 .domainEventType(type)
                 .checked(checked)
                 .build();
+    }
+
+    public static MemberEvaluation fakeMemberEvaluation(Long evaluationId) {
+        Post post = fakePost(defaultPostID);
+        Member member = fakeMember(defaultMemberID);
+        Member colleague = fakeMember(2L);
+
+        return MemberEvaluation.builder()
+                .id(evaluationId)
+                .post(post)
+                .member(member)
+                .colleague(colleague)
+                .content("test eval")
+                .build();
+    }
+
+    public static MemberEvaluationDTO fakeMemberEvaluationDTO() {
+        return new MemberEvaluationDTO("test eval");
     }
 }


### PR DESCRIPTION
### 작업사항

- 매너 평가 조회 / 작성을 위한 domain, controller, service, repository 작성 
- Controller, Service, Repository layer의 유닛 테스트 작성
- 공동구매 주최자가 실제 공동구매가 끝났을 때 post의 상태를 buying_complete으로 바꾸면, 
구매 참여자들에게 동료 매너 평가 form 링크가 알림으로 전송되도록 기능 추가