### PR TITLE
LazyConnectionDataSourceProxy 적용

### DIFF
--- a/src/main/java/com/flab/buywithme/config/DataSourceConfig.java
+++ b/src/main/java/com/flab/buywithme/config/DataSourceConfig.java
@@ -1,0 +1,22 @@
+package com.flab.buywithme.config;
+
+import com.zaxxer.hikari.HikariDataSource;
+import javax.sql.DataSource;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
+
+@Configuration
+public class DataSourceConfig {
+
+    @Bean
+    public DataSource lazyDataSource(DataSourceProperties properties) {
+        HikariDataSource dataSource = new HikariDataSource();
+        dataSource.setJdbcUrl(properties.getUrl());
+        dataSource.setUsername(properties.getUsername());
+        dataSource.setPassword(properties.getPassword());
+        dataSource.setDriverClassName(properties.getDriverClassName());
+        return new LazyConnectionDataSourceProxy(dataSource);
+    }
+}


### PR DESCRIPTION
### 작업 사항
커넥션이 실제로 필요한 시점에 커넥션을 점유할 수 있도록, LazyConnectionDataSourceProxy 빈 등록